### PR TITLE
chore(ci): check difference after installing puppeteer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - checkout
       - puppeteer/install
+      - run: exit $(git diff | wc -l)
 
 workflows:
   version: 2.1

--- a/orb.yml
+++ b/orb.yml
@@ -21,4 +21,4 @@ commands:
     - run:
         name: Install puppeteer with chronium
         command: |
-          npm i puppeteer
+          npm ci puppeteer


### PR DESCRIPTION
Hi @threetreeslight :wave:

Thank you for really nice orb! :+1: 
This orb is really useful for me and I'm using this orb on my project from few month ago. 
Actually, I'm checking difference of code in my CI job to check format missing, generation missing something like that using `git diff`.
From this week, this orb is making changes after install puppeteer by npm.
So I made changes to use `clean install` command and check no difference no CI job.
Could you check this PR it's acceptable for you or not :bow:
Please let me know anything :pray:
Again, thank you very much! :bow: